### PR TITLE
Fix defect with workspace-language

### DIFF
--- a/client-app-ts/package-lock.json
+++ b/client-app-ts/package-lock.json
@@ -5580,11 +5580,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5597,15 +5599,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5708,7 +5713,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5718,6 +5724,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5730,17 +5737,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5757,6 +5767,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5829,7 +5840,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5839,6 +5851,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5944,6 +5957,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/client-app-ts/src/editor/TextContentEditor.tsx
+++ b/client-app-ts/src/editor/TextContentEditor.tsx
@@ -15,6 +15,7 @@ interface IProps {
 }
 interface IState {
     guid: string;
+    language?: string;
 }
 
 export class TextContentEditor extends React.Component<IProps, IState> {
@@ -50,6 +51,20 @@ export class TextContentEditor extends React.Component<IProps, IState> {
         }
         if (nextProps.initialValue !== this.editor.getValue()) {
             this.editor.setValue(nextProps.initialValue);
+        }
+        const editorModel = this.editor.getModel();
+        if (editorModel != null && nextProps.language !== this.state.language) {
+            console.log({
+                nextPropsLanguage: nextProps.language,
+                stateLanguage: this.state.language
+            });
+            monaco.editor.setModelLanguage(
+                editorModel,
+                nextProps.language || "plaintext"
+            );
+            this.setState({
+                language: nextProps.language
+            });
         }
     }
 

--- a/client-app-ts/src/workspace/components/editor/WorkspaceEditor.tsx
+++ b/client-app-ts/src/workspace/components/editor/WorkspaceEditor.tsx
@@ -95,7 +95,7 @@ export default class WorkspaceEditor extends Component<IProps, IState> {
                     </div>
                     <div
                         style={{
-                            height: "100%",
+                            height: "99%",
                             padding: "0.1em",
                             minHeight: "20em"
                         }}

--- a/client-app-ts/src/workspace/components/editor/content/WorkspaceFileEdit.tsx
+++ b/client-app-ts/src/workspace/components/editor/content/WorkspaceFileEdit.tsx
@@ -17,14 +17,16 @@ export default class WorkspaceFileEdit extends Component<IProps, IState> {
     public render(): JSX.Element {
         const { fileContent } = this.props;
         if (!fileContent) {
-            return <div style={{ textAlign: "center" }}>NO FILE SELECTED!!!</div>;
+            return (
+                <div style={{ textAlign: "center" }}>NO FILE SELECTED!!!</div>
+            );
         }
-
+        console.log(fileContent.languageMode);
         return (
             <TextContentEditor
                 initialValue={fileContent.content}
                 onChange={this.onContentChanged}
-                language="json"
+                language={fileContent.languageMode}
             />
         );
     }

--- a/client-app-ts/src/workspace/model/IWorkspaceState.ts
+++ b/client-app-ts/src/workspace/model/IWorkspaceState.ts
@@ -25,4 +25,45 @@ export interface IWorkspaceFileContent {
     folderList: string[];
     workspace: string;
     content: string;
+    languageMode?: string;
 }
+
+export const getLanguageModeFromFileName = (fileName: string): string => {
+    const extension = fileName.split(".").pop() || "";
+
+    switch (extension.toLocaleLowerCase()) {
+        case "json":
+            return "json";
+        case "cs":
+        case "csx":
+            return "csharp";
+        case "html":
+            return "html";
+        case "js":
+            return "javascript";
+        case "ts":
+            return "typescript";
+        case "xml":
+            return "xml";
+        case "css":
+            return "css";
+        case "less":
+            return "less";
+        case "scss":
+            return "scss";
+        case "sql":
+            return "sql";
+        case "ps1":
+            return "powershell";
+        case "php":
+            return "php";
+        case "md":
+            return "markdown";
+        case "java":
+            return "java";
+        case "dockerfile":
+            return "dockerfile";
+        default:
+            return "plaintext";
+    }
+};

--- a/client-app-ts/src/workspace/store/WorkspaceStore.ts
+++ b/client-app-ts/src/workspace/store/WorkspaceStore.ts
@@ -1,4 +1,5 @@
 import { eventService } from "../../shared/EventService";
+import { getLanguageModeFromFileName } from '../model/IWorkspaceState';
 import {
     IWorkspace,
     IWorkspaceEditorExplorer,
@@ -48,6 +49,7 @@ const setFileContent = (fileContent: IWorkspaceFileContent) => {
     if (fileContent.workspace === undefined) {
         return;
     }
+    fileContent.languageMode = getLanguageModeFromFileName(fileContent.fileName);
     STATE.fileContent.set(createFileContentKey(fileContent), fileContent);
     eventService.publish({ name: WORKSPACE_STORE_CHANGED });
 };


### PR DESCRIPTION
Added getLanguageModeFromFileName for figuring out monaco language.
This parses the extension from the passed in file name.
Using the extension to return the language it maps to.

Fixes #3 